### PR TITLE
install makefile target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+main
+main.o

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,14 @@ all: main
 
 main: $(OBJS)
 	$(CC) -o main $^ $(LDFLAGS)
+
+clean:
+	$(RM) *~ *.o main
+
+ifeq ($(PREFIX),)
+    PREFIX := /usr/local
+endif
+
+install:
+	install -d $(DESTDIR)$(PREFIX)/lib/
+	install -m 644 target/debug/libniiiice.so $(DESTDIR)$(PREFIX)/lib/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+Instructions for Linux:
+
+```
+$ cargo build
+$ make
+$ sudo make install
+$ sudo ldconfig
+$ ./main
+```


### PR DESCRIPTION
I encountered this error when trying to execute the `main` binary:

```
$ ./main 
./main: error while loading shared libraries: libniiiice.so: cannot open shared object file: No such file or directory
```

That's because dynamic linker run-time bindings were not properly set on my system.

So I added an `install` target to `Makefile`, which populates `/usr/local/lib/libniiiice.so`.
The command `ldconfig` updates the runtime bindings, so then the `main` binary is able to be executed.